### PR TITLE
Fix support for redis.Cluster

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ function timeout(command, ms, redis) {
   if (!ms) {
     return originCommand;
   }
+  if (typeof originCommand !== 'function') {
+    return originCommand;
+  }
   redis['_' + command] = originCommand.bind(redis);
   redis[command] = function () {
     var args = [].slice.call(arguments);


### PR DESCRIPTION
When using a redis.Cluster instance, this module does not work because some property of the redis.Cluster object are undefined (or at least not a function):

```
ioredis-timeout/index.js:21
  redis['_' + command] = originCommand.bind(redis);
                                      ^
TypeError: Cannot read property 'bind' of undefined
````

This PR checks if the replaced property is a function or something else.