### PR TITLE
Suppress warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ redis
 // { [redis.get: Executed timeout 5000 ms] name: 'redis.get', args: [ 'key' ] }
 ```
 
+Suppress warnings by adding an optional parameter
+```
+RedisTimeout(redis, 5000, true);
+```
+
 ### Test
 
 ```

--- a/index.js
+++ b/index.js
@@ -2,25 +2,27 @@
 
 var commands = require('ioredis-commands');
 
-function timeoutAll(redis, ms) {
+function timeoutAll(redis, ms, suppressWarnings) {
   if (!ms) {
     return redis;
   }
   Object.keys(commands).forEach(function (command) {
-    timeout(command, ms, redis);
+    timeout(command, ms, redis, suppressWarnings);
   });
 
   return redis;
 }
 
-function timeout(command, ms, redis) {
+function timeout(command, ms, redis, suppressWarnings) {
   var originCommand = redis['_' + command] || redis[command];
   if (!ms || (typeof originCommand !== 'function')) {
     return originCommand;
   }
 
   if (['multi', 'pipeline'].indexOf(command) !== -1) {
-    console.warn('ioredis-timeout not support .pipeline or .multi')
+    if (!suppressWarnings) {
+      console.warn('ioredis-timeout not support .pipeline or .multi')
+    }
     return originCommand;
   }
   redis['_' + command] = originCommand.bind(redis);


### PR DESCRIPTION
Add parameter suppressWarnings

To make it possible to suppress warnings.
The warnings are good initially, to make developers aware of the issue, but eventually they become unnecessary noise in the logs.