### PR TITLE
allow callback form - closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,18 @@ redis
   .then(console.log)
   .catch(console.error);
 
+redis
+  .get('key', function(err, result) {
+    if(err) {
+      console.error(err);
+    }
+    if(result) {
+      console.log(result);
+    }
+  });
+
 // { [redis.set: Executed timeout 500 ms] name: 'redis.set', args: [ 'key', 'value' ] }
+// { [redis.get: Executed timeout 5000 ms] name: 'redis.get', args: [ 'key' ] }
 // { [redis.get: Executed timeout 5000 ms] name: 'redis.get', args: [ 'key' ] }
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "timeout"
   ],
   "dependencies": {
-    "ioredis-commands": "^4.0.0"
+    "ioredis-commands": "^4.0.0",
+    "standard-as-callback": "^2.0.1"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -17,3 +17,13 @@ redis
   .get('key')
   .then(console.log)
   .catch(console.error);
+
+redis
+  .get('key', function(err, result) {
+    if(err) {
+      console.error(err);
+    }
+    if(result) {
+      console.log(result);
+    }
+  });


### PR DESCRIPTION
Hi!

First of all thank you for your library that saved me a lot of headaches managing `io-redis` timeouts!

I've encountered the same issue as @nicokaiser reported in #1 

`io-redis` uses the standard bluebird for promises and allows the use of a callback syntax (see https://github.com/luin/ioredis/blob/master/README.md).

Some libraries are using the callback style to perform requests through `io-redis`. It is the case with `connect-redis` as pointed in #1.

In the event of a timeout the thrown error results in `Unhandled Rejection` warnings which can saturate the logs.

To fix this issue I introduced the use of `standard-as-callback` which is already an `io-redis` dependency, so it won't increase the final dependency stack.

Thank you again for your time!